### PR TITLE
Build ct_config from sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,12 @@ RUN TF_VERSION="0.11.3"; \
 # Links:
 # 1 - https://github.com/coreos/terraform-provider-ct/issues/21
 
-# Install Go 1.9.
+# Install Go 1.10.
 RUN add-apt-repository --yes ppa:gophers/archive && \
     apt-get update && \
-    apt-get install -y golang-1.9-go && \
+    apt-get install -y golang-1.10-go && \
     rm -rf /var/lib/apt/lists/* && \
-    ln -sf /usr/lib/go-1.9/bin/go /usr/local/bin/go
+    ln -sf /usr/lib/go-1.10/bin/go /usr/local/bin/go
 
 # Build ct_config provider from sources.
 RUN export GOPATH="/opt/go" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:xenial
 
 RUN apt-get update && \
-    apt-get install -y apt-transport-https python python-pip openssl curl wget git unzip
+    apt-get install -y apt-transport-https python python-pip openssl curl wget git unzip \
+        software-properties-common
 
 # Install Azure CLI.
 RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" > \
@@ -9,8 +10,7 @@ RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheez
     apt-key adv --keyserver packages.microsoft.com \
       --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893 && \
     apt-get update && \
-    apt-get install -y azure-cli && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y azure-cli
 
 # Install AWS CLI.
 RUN pip install awscli --upgrade
@@ -21,7 +21,22 @@ RUN TF_VERSION="0.11.3"; \
     unzip terraform_${TF_VERSION}_linux_amd64.zip -d /bin && \
     rm -f terraform_${TF_VERSION}_linux_amd64.zip
 
-# Get ct_config terraform provider.
-RUN CT_PROV_VERSION="v0.2.1"; \
-    wget https://github.com/coreos/terraform-provider-ct/releases/download/${CT_PROV_VERSION}/terraform-provider-ct-${CT_PROV_VERSION}-linux-amd64.tar.gz && \
-    tar xf terraform-provider-ct-${CT_PROV_VERSION}-linux-amd64.tar.gz -C /bin --strip=1
+# We need to build ct_config terraform provider from sources, because of two things:
+# 1. it's still not avaialble in terraform repos [1].
+# 2. latest binary release v0.2.1 is too old and does not support passwd groups.
+#
+# Links:
+# 1 - https://github.com/coreos/terraform-provider-ct/issues/21
+
+# Install Go 1.9.
+RUN add-apt-repository --yes ppa:gophers/archive && \
+    apt-get update && \
+    apt-get install -y golang-1.9-go && \
+    rm -rf /var/lib/apt/lists/* && \
+    ln -sf /usr/lib/go-1.9/bin/go /usr/local/bin/go
+
+# Build ct_config provider from sources.
+RUN export GOPATH="/opt/go" && \
+    mkdir -p ${GOPATH} && \
+    go get -u github.com/coreos/terraform-provider-ct && \
+    ln -sf ${GOPATH}/bin/terraform-provider-ct /bin/terraform-provider-ct


### PR DESCRIPTION
we need latest version of terraform ct provider, otherwise passwd groups get ignored and users are created w/o groups.