### PR TITLE
add-user-jenkins and install ansible via pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ RUN curl -o /usr/local/bin/kubectl  \
     https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
-# add github ssh signature
-ADD ./.github_known_host /root/.ssh/known_hosts
-
 # create user with jenkins id
-RUN useradd -u 113 jenkins -m
+RUN useradd -u 113 jenkins -m && mkdir -p /home/jenkins/.ssh -m 700
+
+# add github ssh signature
+ADD ./.github_known_host /home/jenkins/.ssh/known_hosts

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV KUBECTL_VERSION "v1.11.3"
 
 RUN apt-get update && \
     apt-get install -y apt-transport-https python python-pip openssl curl wget git unzip \
-        software-properties-common wget curl openssh-client openvpn
+        software-properties-common wget curl openssh-client openvpn ansible
 
 # Install Azure CLI.
 RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" > \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV KUBECTL_VERSION "v1.11.3"
 
 RUN apt-get update && \
     apt-get install -y apt-transport-https python python-pip openssl curl wget git unzip \
-        software-properties-common wget curl openssh-client openvpn ansible
+        software-properties-common wget curl openssh-client openvpn
 
 # Install Azure CLI.
 RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" > \
@@ -23,6 +23,9 @@ RUN TF_VERSION="0.11.8"; \
     wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip && \
     unzip terraform_${TF_VERSION}_linux_amd64.zip -d /bin && \
     rm -f terraform_${TF_VERSION}_linux_amd64.zip
+
+# Install ansible
+RUN pip install ansible --upgrade
 
 # We need to build ct_config terraform provider from sources, because of two things:
 # 1. it's still not avaialble in terraform repos [1].

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN curl -o /usr/local/bin/kubectl  \
     chmod +x /usr/local/bin/kubectl
 
 # create user with jenkins id
-RUN useradd -u 113 jenkins -m && mkdir -p /home/jenkins/.ssh -m 700
+RUN useradd -u 113 jenkins -m
 
 # add github ssh signature
-ADD ./.github_known_host /home/jenkins/.ssh/known_hosts
+ADD ./.github_known_host /home/jenkins/known_hosts

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,4 +56,4 @@ RUN curl -o /usr/local/bin/kubectl  \
 ADD ./.github_known_host /root/.ssh/known_hosts
 
 # create user with jenkins id
-RUN useradd -u 113 -g 117 jenkins -m
+RUN useradd -u 113 jenkins -m

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,4 @@ RUN curl -o /usr/local/bin/kubectl  \
     chmod +x /usr/local/bin/kubectl
 
 # create user with jenkins id
-RUN useradd -u 113 jenkins -m
-
-# add github ssh signature
-ADD ./.github_known_host /home/jenkins/known_hosts
+RUN groupadd -g 117 jenkins && useradd -u 113 jenkins -g 117 -m

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,3 +54,6 @@ RUN curl -o /usr/local/bin/kubectl  \
 
 # add github ssh signature
 ADD ./.github_known_host /root/.ssh/known_hosts
+
+# create user with jenkins id
+RUN useradd -u 113 -g 117 jenkins -m


### PR DESCRIPTION
for opsctl there has to be real user as we use it in many places for temp directories
```
{"caller":"github.com/giantswarm/opsctl/command/update/mayu/command.go:113","level":"error","message":"user: unknown userid 113","stack":"[{/go/src/github.com/giantswarm/opsctl/command/update/mayu/command.go:146: } {/go/src/github.com/giantswarm/opsctl/service/installation/installation.go:121: } {/go/src/github.com/giantswarm/opsctl/service/installation/repo/repo.go:123: } {user: unknown userid 113}]","time":"2018-10-23T13:59:50.914897+00:00","verbosity":0}
```

Id  is taken from  debug output in conveyor

+ add ansible binary